### PR TITLE
Fixed Temporary Moved Issue

### DIFF
--- a/src/get.js
+++ b/src/get.js
@@ -28,7 +28,7 @@ module.exports = (school, year, month, callback = initCallback) => {
   }
 
   const payload = {
-    url: `http://${ domain }/sts_sci_md00_001.do`,
+    url: `https://${ domain }/sts_sci_md00_001.do`,
     form: `schulCode=${ school }&schulCrseScCode=4&ay=${ year }&mm=${ zerolFill(month) }`
   }
 


### PR DESCRIPTION
When request uses http, the server returns `Temporary Moved`.
```
<!DOCTYPE HTML PUBLIC "-//IETF/DTD HTML 2.0//EN">
<HTML><BODY>Temorary Moved</BODY></HTML>
```