### PR TITLE
디미고 섹션 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ Calcium
 
 Korea School Meal Information API
 
-*NOTE: Digital Media Highschool is NOT supported. See the [Dimigo](#dimigo) section for more info.*
-
 Usage
 -----
 
@@ -45,9 +43,3 @@ Example
 ]
 >
 ```
-
-Dimigo
-------
-
-Dimigo has school code of `J100000855`, but they DOES NOT upload meal info to
-NEIS server. you may find something useful from [Dimigoin](https://dimigo.in).


### PR DESCRIPTION
현재 디지털미디어고등학교의 식단이 정상적으로 나오고 있어 문단을 삭제하였습니다.